### PR TITLE
modified requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python >= 3.7
+#python >= 3.7
 numpy
 matplotlib
 hypothesis


### PR DESCRIPTION
I was trying to work with this [issue](https://github.com/amogorkon/fuzzylogic/issues/19)  and while installing requirements got a error message so thought it would be nice 

just commented out python >= 3.7, so that if some beginner tries to pip install -r requirements, he/she may not get to see this message 
```
ERROR: Could not find a version that satisfies the requirement python>=3.7 (from versions: none)
ERROR: No matching distribution found for python>=3.7
```
and as it is commented out users can still see mentioned python version 